### PR TITLE
Add conversation support for rooms (Channels & Multiperson Direct Messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Have a multi-message chat with your bot.
 1) Make a new `Conversation` instance aware of your robot:
     
    ```javascript
-   var switchBoard = new Conversation(robot, type);
+   var switchBoard = new Conversation(robot, [type]);
    ```
     
-This will register a custom listener allowing the instance to check all incoming messages. Type parameter can take one of two values: `user` (default) or `room`. It defines is this conversation with whole room or with particular user only.
-If the message comes from a user(room) that we're having a conversation with, it will be processed as the next step in an ongoing Dialog.
+This will register a custom listener allowing the instance to check all incoming messages. Type parameter can take one of two values: `user` (default) or `room`. It defines if this conversation is with the whole room or with a particular user only.
+If the message comes from a user (or a room) that we're having a conversation with, it will be processed as the next step in an ongoing Dialog.
 
 2) Given an starting message, create a new Dialog instance and give the dialog choices.
   
@@ -32,7 +32,7 @@ If the message comes from a user(room) that we're having a conversation with, it
   });
   ```
 
-The switchBoard will listen to the next message from the same user(room) and try to match it to any of the available choices.
+The switchBoard will listen to the next message from the same user (or room) and try to match it to any of the available choices.
 After a match has been found. It will clear the choices, and end the dialog.
 
 The bot will forget about your dialog after a default timeout of 30 seconds.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Have a multi-message chat with your bot.
 1) Make a new `Conversation` instance aware of your robot:
     
    ```javascript
-   var switchBoard = new Conversation(robot);
+   var switchBoard = new Conversation(robot, type);
    ```
     
-This will register a custom listener allowing the instance to check all incoming messages. If the message comes
-from a user that we're having a conversation with, it will be processed as the next step in an ongoing Dialog.
+This will register a custom listener allowing the instance to check all incoming messages. Type parameter can take one of two values: `user` (default) or `room`. It defines is this conversation with whole room or with particular user only.
+If the message comes from a user(room) that we're having a conversation with, it will be processed as the next step in an ongoing Dialog.
 
 2) Given an starting message, create a new Dialog instance and give the dialog choices.
   
@@ -32,7 +32,7 @@ from a user that we're having a conversation with, it will be processed as the n
   });
   ```
 
-The switchBoard will listen to the next message **FROM THE SAME USER** and try to match it to any of the available choices.
+The switchBoard will listen to the next message from the same user(room) and try to match it to any of the available choices.
 After a match has been found. It will clear the choices, and end the dialog.
 
 The bot will forget about your dialog after a default timeout of 30 seconds.

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,16 +10,20 @@ module.exports = function Conversation(bot, type) {
     var _talkingTo = {};//TODO: Use the robot brain for this, it will probably be more scalable.
     type = type || 'user';
 
+    var getId = function(msg) {
+        return (type === 'user')? msg.user.id : msg.room;
+    };
+
     //Register a custom listener that will spy on all incoming messages
     bot.listen(
         function matcher(msg) {
-            var id = (type === 'user')? msg.user.id : msg.room;
+            var id = getId(msg);
             //If a dialog is currently open with this user, accept the message.
             debug('Checking if talking to   ' + id + ' = ' + !!_talkingTo[id]);
             return _talkingTo[id];
         },
         function spy(msg) {
-            var id = (type === 'user')? msg.message.user.id : msg.message.room;
+            var id = getId(msg.message);
             debug('Accepting message for ', id);
             _talkingTo[id].receive(msg);
         }
@@ -32,7 +36,7 @@ module.exports = function Conversation(bot, type) {
      * @returns Dialog
      */
     this.startDialog = function startDialog(msg, timeout) {
-        var id = (type === 'user')? msg.message.user.id: msg.message.room,
+        var id = getId(msg.message),
             dialog = _talkingTo[id] = new Dialog(msg, timeout);
 
         //When the dialog times out, unregister it.

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,34 +5,34 @@
 var Dialog = require('./Dialog'),
     debug = require('debuglog')('HUBOT_CONVERSATION');
 
-module.exports = function Conversation(bot) {
+module.exports = function Conversation(bot, type) {
 
     var _talkingTo = {};//TODO: Use the robot brain for this, it will probably be more scalable.
+    type = type || 'user';
 
     //Register a custom listener that will spy on all incoming messages
     bot.listen(
         function matcher(msg) {
-            var user = msg.user.id;
+            var id = (type === 'user')? msg.user.id : msg.room;
             //If a dialog is currently open with this user, accept the message.
-            debug('Checking if talking to   ' + user + ' = ' + !!_talkingTo[user]);
-            return _talkingTo[user];
+            debug('Checking if talking to   ' + id + ' = ' + !!_talkingTo[id]);
+            return _talkingTo[id];
         },
         function spy(msg) {
-
-            var user = msg.message.user.id;
-            debug('Accepting message for ', user);
-            _talkingTo[user].receive(msg);
+            var id = (type === 'user')? msg.message.user.id : msg.message.room;
+            debug('Accepting message for ', id);
+            _talkingTo[id].receive(msg);
         }
     );
 
     /**
-     * Starts an empty conversation with the user associated to an incoming message
+     * Starts an empty conversation with the user or room associated to an incoming message
      * @param msg An incoming message on which to base a conversation
      * @param timeout (Optional), Default: 30000 ms Expiration time for the conversation.
      * @returns Dialog
      */
     this.startDialog = function startDialog(msg, timeout) {
-        var id = msg.message.user.id,
+        var id = (type === 'user')? msg.message.user.id: msg.message.room,
             dialog = _talkingTo[id] = new Dialog(msg, timeout);
 
         //When the dialog times out, unregister it.
@@ -43,12 +43,11 @@ module.exports = function Conversation(bot) {
     };
 
     /**
-     * Returns an existing Dialog with a given user id.
+     * Returns an existing Dialog with a given user or room id.
      * @param userId
      * @returns {*}
      */
-    this.talkingTo = function talkingTo(userId) {
-        return _talkingTo[userId];
+    this.talkingTo = function talkingTo(id) {
+        return _talkingTo[id];
     };
 };
-

--- a/test/unit/room_conversation_test.js
+++ b/test/unit/room_conversation_test.js
@@ -1,0 +1,93 @@
+/**
+ * Created by Ivan Dmitriev on /30/15.
+ */
+/*eslint max-nested-callbacks:[0]*/
+'use strict';
+require('coffee-script/register');
+
+var hubot = require('hubot'),
+    Robot = hubot.Robot,
+    Message = hubot.TextMessage,
+    utils = require('../utils'),
+    assert = require('chai').assert,
+    Conversation = require('../../'),
+    testUser = new hubot.User('Lenny', {room: 'The Lounge'}),
+    testUserSameRoom = new hubot.User('Jonny', {room: 'The Lounge'}),
+    testUserDiffRoom = new hubot.User('Lenny', {room: 'Another room'})
+    ;
+
+describe('#Hubot Room Conversation', function () {
+    var bot, roomSwitchBoard, roomMessages, messenger;
+
+    beforeEach(function () {
+        //reset the bot;
+        bot = new Robot('hubot/src/adapters', 'shell');
+        roomSwitchBoard = new Conversation(bot, 'room');
+    });
+
+    afterEach(function () {
+        bot.shutdown();
+    });
+
+    it('Starts a conversation in room', function (done) {
+        bot.respond(/FooBar/i, function (msg) {
+            roomSwitchBoard.startDialog(msg);
+            assert.ok(roomSwitchBoard.talkingTo(msg.message.room), 'Conversation has begun');
+            done();
+        });
+        bot.receive(new Message(testUser, 'hubot FooBar', '123'));
+    });
+
+
+    it('Dialog can recognize next input from different users in a room', function (done) {
+        roomMessages = [
+            new Message(testUser, 'hubot clean the house', '123'),
+            new Message(testUserSameRoom, 'the kitchen', '456'),
+            new Message(testUser, 'yes', '789')
+        ];
+        messenger = new utils.Messenger(bot, roomMessages);
+
+        bot.respond(/clean the house/i, function (msg) {
+            var dialog = roomSwitchBoard.startDialog(msg);
+            msg.reply('Should I start with the kitchen or the bathroom?');
+
+            dialog.addChoice(/(kit)chen/, function (msg2) {
+                msg2.reply('Ok! Cleaning the kitchen');
+                done();
+            });
+
+            messenger.next();
+        });
+
+        messenger.next();
+    });
+
+    it('Dialog can recognize next input from the same room only', function (done) {
+        roomMessages = [
+            new Message(testUser, 'hubot clean the house', '123'),
+            new Message(testUserDiffRoom, 'the kitchen', 'diff room 456'),
+            new Message(testUserSameRoom, 'the kitchen', '456'),
+            new Message(testUser, 'yes', '789')
+        ];
+        messenger = new utils.Messenger(bot, roomMessages);
+
+        bot.respond(/clean the house/i, function (msg) {
+            var dialog = roomSwitchBoard.startDialog(msg);
+            msg.reply('Should I start with the kitchen or the bathroom?');
+
+            dialog.addChoice(/(kit)chen/, function (msg2) {
+                msg2.reply('Ok! Cleaning the kitchen');
+                if (msg2.message.id !== '456') {
+                    throw new Error('This user message from different room, it should be ignored.');
+                }
+                done();
+            });
+
+            messenger.next();
+            messenger.next();
+        });
+
+        messenger.next();
+    });
+
+});


### PR DESCRIPTION
Sometimes it's useful to have a conversation with a whole room. I have added a type parameter to Conversation constructor to allow choosing user or room conversation scope, keeping user based conversation by default.

It's a bit raw version (but it works),  and it would be great to get a feedback and complete this feature.
