### PR TITLE
Handle timeout when choices are now empty

### DIFF
--- a/lib/Dialog.js
+++ b/lib/Dialog.js
@@ -120,7 +120,8 @@ var Dialog = function Dialog(originalMessage, timeoutValue, timeoutMessage) {
      * @param msg The message that started this dialog
      */
     this.dialogTimeout = function (msg) {
-        msg.reply(timeoutMessage);
+        if choices.length > 0
+            msg.reply(timeoutMessage);
     };
 
 


### PR DESCRIPTION
Currently when I call resetChoices I can no longer guarantee that the timeouts have been cleaned up. If there are no more choices then there should be no more timeouts. This will guard that the timeout message is never sent if there are no options to choose from.