### PR TITLE
Unregister a dialog

### DIFF
--- a/lib/Dialog.js
+++ b/lib/Dialog.js
@@ -124,7 +124,13 @@ var Dialog = function Dialog(originalMessage, timeoutValue, timeoutMessage) {
             msg.reply(timeoutMessage);
         }
     };
-
+    
+    /**
+     * Unregister the dialog at the end of the last dialog choice 
+     */
+    this.finish = function() {
+        self.emit('timeout');
+    }
 
     //Start the clock on any new instance
     startDialogTimeout();


### PR DESCRIPTION
When running on a "hubot-conversation" dialog and the user enters the last choice of it, that dialog doesn't get unregistered. So a possible robot.catchAll() listener in another script, it doesn't catch any messages even when the user is not running in a specific "hubot-conversation" dialog. Using the finish() function, solves that problem.

So it will be something like this: 

    robot.respond(/clean the house/, function (msg) {
        var dialog = switchBoard.startDialog(msg);

        msg.reply('Sure, where should I start? Kitchen or Bathroom');
        dialog.addChoice(/kitchen/i, function (msg2) {
            msg2.reply('On it boss!');
            dialog.finish(); // <<--------------
        });
        dialog.addChoice(/bathroom/i, function (msg2) {
            msg.reply('Do I really have to?');
            dialog.addChoice(/yes/, function (msg3) {
                msg3.reply('Fine, Mom!');
                dialog.finish(); // <<--------------
            })
        });
    });
